### PR TITLE
Enforce whole archive linking on libfaiss_*.a

### DIFF
--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -114,7 +114,12 @@ if (${CONFIG_FAISS} STREQUAL ON OR ${CONFIG_ALL} STREQUAL ON OR ${CONFIG_TEST} S
         ${CMAKE_CURRENT_SOURCE_DIR}/src/faiss_index_service.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/faiss_methods.cpp
     )
-    target_link_libraries(${TARGET_LIB_FAISS} ${TARGET_LINK_FAISS_LIB} ${TARGET_LIB_UTIL} /usr/local/nvidia/lib64/libcuda.so OpenMP::OpenMP_CXX)
+    target_link_libraries(${TARGET_LIB_FAISS}
+        "$<LINK_LIBRARY:WHOLE_ARCHIVE,${TARGET_LINK_FAISS_LIB}>"
+        ${TARGET_LIB_UTIL}
+        /usr/local/nvidia/lib64/libcuda.so
+        OpenMP::OpenMP_CXX
+    )
     target_include_directories(${TARGET_LIB_FAISS} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/include
         $ENV{JAVA_HOME}/include

--- a/jni/cmake/init-faiss.cmake
+++ b/jni/cmake/init-faiss.cmake
@@ -80,6 +80,9 @@ find_package(LAPACK REQUIRED)
 # Set relevant properties
 set(BUILD_TESTING OFF)          # Avoid building faiss tests
 set(FAISS_ENABLE_GPU ON)
+if(${FAISS_ENABLE_GPU} STREQUAL ON)
+    set(CMAKE_CUDA_COMPILER_LAUNCHER "ccache")
+endif()
 set(FAISS_ENABLE_PYTHON OFF)
 
 if(NOT DEFINED AVX2_ENABLED)


### PR DESCRIPTION
### Description
We need this because:
1. when enable faiss gpu, libfaiss_gpu.a got created and linked to the main opensearchknn_faiss_*.so
2. this libfaiss_gpu has dependency on libfaiss_*.a (the cpu faiss lib)
3. some symbols in the libfaiss_*.a got ignored during linking, causing runtime link error like 
```
java.lang.UnsatisfiedLinkError: /home/user/jiasen/k-NN-gpu/jni/release/libopensearchknn_faiss_avx512.so: /home/user/jiasen/k-NN-gpu/jni/release/libopensearchknn_faiss_avx512.so: undefined symbol: _ZTIN5faiss14ParameterSpaceE
```

The fix is to enforce *whole archive* linking on libfaiss_*.a so that all symbols are pulled during the link

Also, introduce `ccache` as build launcher to accelerate cuda files rebuild

### Related Issues

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
